### PR TITLE
feature: add ability to sleep in mio implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,89 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "mio"
@@ -27,10 +100,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaac441002f822bc9705a681810a4dd2963094b9ca0ddc41cb963a4c189189ea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5011c7e263a695dc8ca064cddb722af1be54e517a280b12a5356f98366899e5d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rustix"
+version = "0.38.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "server"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
+ "log",
  "mio",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -38,6 +164,37 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+env_logger = "0.10.0"
+log = "0.4.20"
 mio = { version = "0.8.8", features = [ "os-poll", "net" ] }

--- a/drill.yaml
+++ b/drill.yaml
@@ -1,6 +1,6 @@
-concurrency: 1
+concurrency: 4
 base: "http://localhost:6969"
-iterations: 10
+iterations: 4
 
 plan:
   - name: Fetch base

--- a/drill.yaml
+++ b/drill.yaml
@@ -1,6 +1,6 @@
-concurrency: 4
+concurrency: 150
 base: "http://localhost:6969"
-iterations: 4
+iterations: 150
 
 plan:
   - name: Fetch base

--- a/src/bin/mio_async.rs
+++ b/src/bin/mio_async.rs
@@ -1,14 +1,32 @@
-use std::{collections::HashMap, io::Write};
+use std::{
+    collections::{HashMap, VecDeque},
+    io::Write,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
+use log;
 use mio::{
     net::{TcpListener, TcpStream},
     Events, Interest, Poll, Token,
 };
+
 use server::handle_mio_connection;
 
+/// Get the current unix timestamp accurate to miliseconds
+fn get_unix_timestamp() -> u128 {
+    let start = SystemTime::now();
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+
+    since_the_epoch.as_millis()
+}
+
 fn main() {
+    env_logger::builder().filter_level(log::LevelFilter::Debug);
     let address = "127.0.0.1:6969";
     let mut listener = TcpListener::bind(address.parse().unwrap()).unwrap();
+    log::info!("Listening on http://{address}");
 
     let mut sockets_hm = HashMap::<usize, TcpStream>::new();
     let mut responses = HashMap::<usize, String>::new();
@@ -19,22 +37,25 @@ fn main() {
         .register(&mut listener, Token(0), Interest::READABLE)
         .unwrap();
 
+    // A queue to register timeouts
+    let mut timer_queue = VecDeque::<(u128, usize)>::new();
+
+    // Can handle 8 events at once
     let mut events = Events::with_capacity(8);
     let mut counter = 1;
     loop {
-        poll.poll(&mut events, None).unwrap();
+        poll.poll(&mut events, Some(Duration::from_millis(10)))
+            .unwrap();
         for event in &events {
-            println!("{event:?}");
             if event.is_readable() {
                 let mut stream = listener.accept().unwrap().0;
 
                 let response = handle_mio_connection(&mut stream);
                 counter += 1;
 
-                println!("writable event registered for token {counter}");
-                poll.registry()
-                    .register(&mut stream, Token(counter), Interest::WRITABLE)
-                    .unwrap();
+                log::error!("writable event registered for token {counter} after 1 seconds");
+                let expire_timeout = get_unix_timestamp() + 1000;
+                timer_queue.push_back((expire_timeout, counter));
 
                 sockets_hm.insert(counter, stream);
                 responses.insert(counter, response);
@@ -56,6 +77,24 @@ fn main() {
                     sockets_hm.remove(&token);
                     responses.remove(&token);
                     println!("Writing done!");
+                }
+            }
+        }
+        // Check if any timer has expired
+        if !timer_queue.is_empty() {
+            let current_timestamp = get_unix_timestamp();
+            while let Some((event_timestamp, _)) = timer_queue.front() {
+                if event_timestamp < &current_timestamp {
+                    // Timer has expired, register interest for writing to the stream
+                    let (_, token) = timer_queue.pop_front().unwrap();
+                    let tcp_stream = sockets_hm.get_mut(&token).unwrap();
+                    poll.registry()
+                        .register(tcp_stream, Token(token), Interest::WRITABLE)
+                        .unwrap();
+                } else {
+                    // later events will not have been expired as per the assuption that
+                    // default timeout that this application supports is 1s
+                    break;
                 }
             }
         }

--- a/src/bin/mio_async.rs
+++ b/src/bin/mio_async.rs
@@ -6,6 +6,7 @@ use std::{
 
 use log;
 use mio::{
+    event::Source,
     net::{TcpListener, TcpStream},
     Events, Interest, Poll, Token,
 };
@@ -41,57 +42,79 @@ fn main() {
     let mut timer_queue = VecDeque::<(u128, usize)>::new();
 
     // Can handle 8 events at once
-    let mut events = Events::with_capacity(8);
+    let mut events = Events::with_capacity(10240);
     let mut counter = 1;
     loop {
         poll.poll(&mut events, Some(Duration::from_millis(10)))
             .unwrap();
         for event in &events {
-            if event.is_readable() {
-                let mut stream = listener.accept().unwrap().0;
+            println!("{event:?}");
+            match event.token() {
+                Token(0) => loop {
+                    let mut stream = match listener.accept() {
+                        Ok((stream, _)) => stream,
+                        Err(err) => {
+                            eprint!("{err:?}");
+                            break;
+                        }
+                    };
+                    println!("Read {counter}");
 
-                let response = handle_mio_connection(&mut stream);
-                counter += 1;
-
-                log::error!("writable event registered for token {counter} after 1 seconds");
-                let expire_timeout = get_unix_timestamp() + 1000;
-                timer_queue.push_back((expire_timeout, counter));
-
-                sockets_hm.insert(counter, stream);
-                responses.insert(counter, response);
-            } else if event.is_writable() {
-                let token = event.token().0;
-                println!("writable event triggered for token {token}");
-
-                let stream = sockets_hm.get_mut(&token).unwrap();
-                let response = responses.get(&token).unwrap();
-
-                if !event.is_write_closed() {
-                    println!("Writing to stream");
                     stream
-                        .write_all(response.as_bytes())
-                        .expect("Could not write to stream");
-                    stream.flush().unwrap();
+                        .register(poll.registry(), Token(counter), Interest::READABLE)
+                        .unwrap();
 
-                    poll.registry().deregister(stream).unwrap();
-                    sockets_hm.remove(&token);
-                    responses.remove(&token);
-                    println!("Writing done!");
+                    sockets_hm.insert(counter, stream);
+                    counter += 1;
+                },
+                _ => {
+                    if event.is_readable() {
+                        let token = event.token().0;
+                        let mut stream = sockets_hm.get_mut(&token).unwrap();
+                        let response = handle_mio_connection(&mut stream);
+
+                        // log::error!("writable event registered for token {token} after 1 seconds");
+                        let expire_timeout = get_unix_timestamp() + 500;
+                        timer_queue.push_back((expire_timeout, token));
+
+                        responses.insert(token, response);
+                    } else if event.is_writable() {
+                        let token = event.token().0;
+                        // prinstln!("writable event triggered for token {token}");
+
+                        let stream = sockets_hm.get_mut(&token).unwrap();
+                        let response = responses.get(&token).unwrap();
+
+                        if !event.is_write_closed() {
+                            // println!("Writing to stream");
+                            stream
+                                .write_all(response.as_bytes())
+                                .expect("Could not write to stream");
+                            stream.flush().unwrap();
+
+                            poll.registry().deregister(stream).unwrap();
+                            sockets_hm.remove(&token);
+                            responses.remove(&token);
+                            // println!("Writing done!");
+                        }
+                    }
                 }
             }
         }
         // Check if any timer has expired
         if !timer_queue.is_empty() {
             let current_timestamp = get_unix_timestamp();
-            while let Some((event_timestamp, _)) = timer_queue.front() {
+            while let Some((event_timestamp, token)) = timer_queue.front() {
                 if event_timestamp < &current_timestamp {
+                    println!("Expired {token}");
                     // Timer has expired, register interest for writing to the stream
                     let (_, token) = timer_queue.pop_front().unwrap();
                     let tcp_stream = sockets_hm.get_mut(&token).unwrap();
-                    poll.registry()
-                        .register(tcp_stream, Token(token), Interest::WRITABLE)
+                    tcp_stream
+                        .reregister(poll.registry(), Token(token), Interest::WRITABLE)
                         .unwrap();
                 } else {
+                    println!("Not expired {event_timestamp} {token}");
                     // later events will not have been expired as per the assuption that
                     // default timeout that this application supports is 1s
                     break;

--- a/src/bin/mio_async.rs
+++ b/src/bin/mio_async.rs
@@ -24,7 +24,10 @@ fn get_unix_timestamp() -> u128 {
 }
 
 fn main() {
-    env_logger::builder().filter_level(log::LevelFilter::Debug);
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Debug)
+        .init();
+
     let address = "127.0.0.1:6969";
     let mut listener = TcpListener::bind(address.parse().unwrap()).unwrap();
     log::info!("Listening on http://{address}");
@@ -48,17 +51,22 @@ fn main() {
         poll.poll(&mut events, Some(Duration::from_millis(10)))
             .unwrap();
         for event in &events {
-            println!("{event:?}");
+            log::info!("Received an event");
+            log::debug!("Event details {event:?}");
+
             match event.token() {
                 Token(0) => loop {
+                    log::info!("Might be a Server event");
                     let mut stream = match listener.accept() {
-                        Ok((stream, _)) => stream,
+                        Ok((stream, _)) => {
+                            log::info!("Accepted a connection");
+                            stream
+                        }
                         Err(err) => {
-                            eprint!("{err:?}");
+                            log::error!("{err:?}");
                             break;
                         }
                     };
-                    println!("Read {counter}");
 
                     stream
                         .register(poll.registry(), Token(counter), Interest::READABLE)
@@ -69,33 +77,35 @@ fn main() {
                 },
                 _ => {
                     if event.is_readable() {
+                        log::info!("Readable event");
+
                         let token = event.token().0;
                         let mut stream = sockets_hm.get_mut(&token).unwrap();
-                        let response = handle_mio_connection(&mut stream);
+                        let (response, sleep_time) = handle_mio_connection(&mut stream);
 
-                        // log::error!("writable event registered for token {token} after 1 seconds");
-                        let expire_timeout = get_unix_timestamp() + 500;
+                        let expire_timeout = get_unix_timestamp() + u128::from(sleep_time);
                         timer_queue.push_back((expire_timeout, token));
 
                         responses.insert(token, response);
                     } else if event.is_writable() {
+                        log::info!("Writable event");
+
                         let token = event.token().0;
-                        // prinstln!("writable event triggered for token {token}");
 
                         let stream = sockets_hm.get_mut(&token).unwrap();
                         let response = responses.get(&token).unwrap();
 
                         if !event.is_write_closed() {
-                            // println!("Writing to stream");
                             stream
                                 .write_all(response.as_bytes())
                                 .expect("Could not write to stream");
+                            log::info!("Writing Done");
+
                             stream.flush().unwrap();
 
                             poll.registry().deregister(stream).unwrap();
                             sockets_hm.remove(&token);
                             responses.remove(&token);
-                            // println!("Writing done!");
                         }
                     }
                 }
@@ -106,15 +116,18 @@ fn main() {
             let current_timestamp = get_unix_timestamp();
             while let Some((event_timestamp, token)) = timer_queue.front() {
                 if event_timestamp < &current_timestamp {
-                    println!("Expired {token}");
+                    log::info!("Timer expired for token {token}");
+
                     // Timer has expired, register interest for writing to the stream
                     let (_, token) = timer_queue.pop_front().unwrap();
                     let tcp_stream = sockets_hm.get_mut(&token).unwrap();
+
+                    log::info!("Registering write interest");
                     tcp_stream
                         .reregister(poll.registry(), Token(token), Interest::WRITABLE)
                         .unwrap();
                 } else {
-                    println!("Not expired {event_timestamp} {token}");
+                    // println!("Not expired {event_timestamp} {token}");
                     // later events will not have been expired as per the assuption that
                     // default timeout that this application supports is 1s
                     break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-pub fn handle_mio_connection(_stream: &mut mio::net::TcpStream) -> String {
+pub fn handle_mio_connection(stream: &mut mio::net::TcpStream) -> String {
     // let buf_reader = BufReader::new(stream);
 
     // The first line of the request contains data in the below format

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,36 +5,34 @@ use std::{
     time::Duration,
 };
 
-pub fn handle_mio_connection(stream: &mut mio::net::TcpStream) -> String {
-    // let buf_reader = BufReader::new(stream);
+pub fn handle_mio_connection(stream: &mut mio::net::TcpStream) -> (String, u16) {
+    let buf_reader = BufReader::new(stream);
 
     // The first line of the request contains data in the below format
     // Method Request-URI HTTP-Version CRLF
     // ex: GET /2 HTTP/1.1
 
-    // let http_request = buf_reader
-    //     .lines()
-    //     .take(1)
-    //     .next()
-    //     .map(|line| {
-    //         println!("Request {line:?}");
-    //         line
-    //     })
-    //     .transpose()
-    //     .ok()
-    //     .flatten()
-    //     .unwrap_or_default();
+    let http_request = buf_reader
+        .lines()
+        .take(1)
+        .next()
+        .map(|line| {
+            log::info!("Request {line:?}");
+            line
+        })
+        .transpose()
+        .ok()
+        .flatten()
+        .unwrap_or_default();
 
-    // let sleep_time = http_request
-    //     .split(" ")
-    //     .nth(1)
-    //     .map(|uri| &uri[1..])
-    //     .filter(|stripped_uri| !stripped_uri.is_empty())
-    //     .map(|sleep_time| sleep_time.parse::<u16>().unwrap());
+    let sleep_time = http_request
+        .split(" ")
+        .nth(1)
+        .map(|uri| &uri[1..])
+        .filter(|stripped_uri| !stripped_uri.is_empty())
+        .map(|sleep_time| sleep_time.parse::<u16>().unwrap());
 
-    // if let Some(sleep_time) = sleep_time {
-    //     std::thread::sleep(Duration::from_millis(sleep_time.into()))
-    // }
+    log::warn!("Sleep for {sleep_time:?} ms");
 
     let status_line = "HTTP/1.1 200 OK";
     let contents = fs::read_to_string("static/index.html").unwrap();
@@ -42,7 +40,7 @@ pub fn handle_mio_connection(stream: &mut mio::net::TcpStream) -> String {
 
     let response = format!("{status_line}\r\nContent-Length: {length}\r\n\r\n{contents}");
 
-    response
+    (response, sleep_time.unwrap_or(1000))
 }
 
 pub fn handle_connection(mut stream: net::TcpStream) {


### PR DESCRIPTION
This PR adds support for handling sleep timers in MIO. It still uses a single thread to manage both requests and timers.

There are two main functionalities of the main program
- To check for any IO events.
- To check for any expired timers.

The IO events are checked by the [poll](https://docs.rs/mio/latest/mio/struct.Poll.html) method of MIO. Now in the same thread we can also check for any expired timers by checking the front of queue ( assumption here is that the queue is sorted by time ). 

The poll() allows to pass a timeout. It means that poll will return after specified time, if there is no event. After poll() returns the queue can be checked.

```rust
// poll for 10ms
poll.poll(&mut events, Some(Duration::from_millis(10)))
            .unwrap();

// check for expired timers
 if !timer_queue.is_empty() {
  // take action on expired timeouts
}
```

<img width="1895" alt="Screenshot 2023-11-15 at 9 09 42 PM" src="https://github.com/Narayanbhat166/web_server_architectures/assets/48803246/58ba7efc-ee22-4eee-bda2-bc9e0b68a991">

